### PR TITLE
redirecting the workflow form to the object page, rather than /cwrc_w…

### DIFF
--- a/includes/workflow.form.inc
+++ b/includes/workflow.form.inc
@@ -475,6 +475,6 @@ function islandora_workflow_rest_entry_form_submit($form, &$form_state) {
         ->fields(array('state' => 'tagged'))
         ->condition('lid', $lid)
         ->execute();
-    drupal_goto('cwrc_workflow');
+    drupal_goto("/islandora/object/$islandora_object->id");
   }
 }


### PR DESCRIPTION
redirecting the workflow form to the object page, rather than /cwrc_workflow

After a workflow stamp form has been filled, it makes more sense to to go to the object page, rather than the skipped workflow entries page.

